### PR TITLE
[SGCC-11] Continuous delivery

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,40 @@
+---
+name: "Release Workflow"
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get tag name
+        id: get_current_tag
+        run: |
+          TAG=$(git describe --tags --abbrev=0)
+          echo "Current tag: $TAG"
+          echo ::set-output name=tag::${TAG}
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.BUILD_KEY }}
+          aws-secret-access-key: ${{ secrets.BUILD_SECRET }}
+          aws-region: eu-west-1
+      - name: Build image
+        uses: neovasili/aws-codebuild@v1.1.1
+        with:
+          aws_region: eu-west-1
+          codebuild_job_name: build-images
+          codebuild_log_group: /aws/codebuild/build-images-project
+          s3_path: ${{ secrets.ARTIFACTS_ACCOUNT }}-build-images-project-source-bucket/orders-backend
+        env:
+          PLAINTEXT_SOURCE_BUCKET_NAME: ${{ secrets.ARTIFACTS_ACCOUNT }}-build-images-project-source-bucket
+          PLAINTEXT_IMAGE_REPO_NAME: orders-backend
+          PLAINTEXT_IMAGE_TAG: ${{ steps.get_current_tag.outputs.tag }}
+          PLAINTEXT_STAGE: int
+          PLAINTEXT_REGION: eu-west-1
+          PLAINTEXT_PREFIX: sgcc
+          PLAINTEXT_AWS_ACCOUNT_ID: ${{ secrets.ARTIFACTS_ACCOUNT }}
+          PLAINTEXT_API_VERSION: v1


### PR DESCRIPTION
This PR adds a new GitHub workflow that essentially will build the deployment docker image and tag it properly according to the tag pushed to the repository, serving as a Continuous Delivery process, since those images will be preserved in the ECR repository and will be ready to be released whenever is needed.